### PR TITLE
Added SharedMemoryHistogram

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(Histogram VERSION 2.0.0 LANGUAGES C CXX)
+project(Histogram VERSION 2.1.0 LANGUAGES C CXX)
 
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 include(cmake/CPM.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ set(headers
     ${CMAKE_CURRENT_SOURCE_DIR}/include/histogram/Histogram3D.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/histogram/Histograms.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/histogram/MamaWriter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/histogram/SharedHistograms.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/histogram/ThreadSafeHistograms.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/histogram/internal/SharedMemoryBackend.h
 )
 set(sources
     ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram/Histogram1D.cpp
@@ -37,6 +39,8 @@ set(sources
     ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram/Histogram3D.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram/Histograms.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram/MamaWriter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram/SharedHistograms.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/histogram/internal/SharedMemoryBackendPosix.cpp
 )
 
 if(ROOT_FOUND)

--- a/all/CMakeLists.txt
+++ b/all/CMakeLists.txt
@@ -12,3 +12,4 @@ enable_testing()
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../test ${CMAKE_BINARY_DIR}/test)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../documentation ${CMAKE_BINARY_DIR}/documentation)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../examples ${CMAKE_BINARY_DIR}/examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.14...3.22)
+project(HistogramExamples LANGUAGES CXX)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/shared_memory ${CMAKE_BINARY_DIR}/shared_memory)

--- a/examples/shared_memory/CMakeLists.txt
+++ b/examples/shared_memory/CMakeLists.txt
@@ -6,11 +6,13 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/CPM.cmake)
 
 # ---- Dependencies ----
 CPMAddPackage(NAME Histogram SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
-find_package(ROOT COMPONENTS RIO Hist RHTTP REQUIRED)
+find_package(ROOT COMPONENTS RIO Hist RHTTP)
 
 add_executable(Server ${CMAKE_CURRENT_SOURCE_DIR}/server_sharedhistograms.cpp)
 target_link_libraries(Server PRIVATE OCL::Histogram)
 set_target_properties(Server PROPERTIES CXX_STANDARD 20)
 
-add_executable(ClientHTTPServer ${CMAKE_CURRENT_SOURCE_DIR}/client_httpserver.cpp)
-target_link_libraries(ClientHTTPServer PRIVATE OCL::Histogram ROOT::Hist ROOT::RIO ROOT::RHTTP)
+if(ROOT_FOUND)
+    add_executable(ClientHTTPServer ${CMAKE_CURRENT_SOURCE_DIR}/client_httpserver.cpp)
+    target_link_libraries(ClientHTTPServer PRIVATE OCL::Histogram ROOT::Hist ROOT::RIO ROOT::RHTTP)
+endif()

--- a/examples/shared_memory/CMakeLists.txt
+++ b/examples/shared_memory/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.14...3.22)
+project(server_client VERSION 1.0 LANGUAGES C CXX)
+
+list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/CPM.cmake)
+
+# ---- Dependencies ----
+CPMAddPackage(NAME Histogram SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
+find_package(ROOT COMPONENTS RIO Hist RHTTP REQUIRED)
+
+add_executable(Server ${CMAKE_CURRENT_SOURCE_DIR}/server_sharedhistograms.cpp)
+target_link_libraries(Server PRIVATE OCL::Histogram)
+set_target_properties(Server PROPERTIES CXX_STANDARD 20)
+
+add_executable(ClientHTTPServer ${CMAKE_CURRENT_SOURCE_DIR}/client_httpserver.cpp)
+target_link_libraries(ClientHTTPServer PRIVATE OCL::Histogram ROOT::Hist ROOT::RIO ROOT::RHTTP)

--- a/examples/shared_memory/client_httpserver.cpp
+++ b/examples/shared_memory/client_httpserver.cpp
@@ -1,0 +1,88 @@
+//
+// Created by Vetle Wegner Ingeberg on 28/04/2026.
+//
+
+
+#include <iostream>
+#include <TMemFile.h>
+#include <TH2.h>
+#include <THttpServer.h>
+
+#include <histogram/SharedHistograms.h>
+#include <csignal>
+
+char leaveprog = 'n';
+
+void keyb_int(int sig_num)
+{
+    if (sig_num == SIGINT || sig_num == SIGQUIT || sig_num == SIGTERM) {
+        printf("\n\nLeaving...\n");
+        leaveprog = 'y';
+    }
+}
+
+TH1* CreateTH1(SharedHistogram1Dp h) {
+    const Axis& xax = h->GetAxisX();
+    const int channels = xax.GetBinCount();
+    TH1* r = new TH1I( h->GetName().c_str(), h->GetTitle().c_str(),
+                       channels, xax.GetLeft(), xax.GetRight() );
+
+    TAxis* rxax = r->GetXaxis();
+    rxax->SetTitle(xax.GetTitle().c_str());
+    rxax->SetTitleSize(0.03);
+    rxax->SetLabelSize(0.03);
+
+    TAxis* ryax = r->GetYaxis();
+    ryax->SetLabelSize(0.03);
+
+    for(int i=0; i<channels+2; ++i)
+        r->SetBinContent(i, h->GetBinContent(i));
+    r->SetEntries( h->GetEntries() );
+
+    return r;
+}
+
+void update_histogram(TH1* rhist, SharedHistogram1Dp oclhist) {
+
+    // check that the root hist and the OCL hist are consistent.
+
+    // Go bin-by-bin and update
+    for (size_t bin = 0; bin < oclhist->GetAxisX().GetBinCount() + 2 ; ++bin) {
+        rhist->SetBinContent(bin, oclhist->GetBinContent(bin));
+    }
+    rhist->SetEntries(oclhist->GetEntries());
+}
+
+int main(int argc, char *argv[]) {
+
+    signal(SIGINT, keyb_int); // set up interrupt handler (Ctrl-C)
+    signal(SIGQUIT, keyb_int);
+    signal(SIGTERM, keyb_int);
+    signal(SIGPIPE, SIG_IGN);
+
+    if ( argc != 1 ) {
+        std::cerr << "Usage: " << argv[0] << std::endl;
+    }
+
+    TFile* file = new TMemFile("test.root", "RECREATE", "Demo");
+    THttpServer* server = new THttpServer("http:8080");
+
+    auto histograms = SharedHistograms::Attach("/test");
+    auto h = histograms.Find1D("hist");
+
+    TH1* hist = CreateTH1(h);
+
+    server->SetTimer(0, true);
+    server->Register("hist", hist);
+    while ( leaveprog == 'n' ) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::cout << h->GetEntries() << std::endl;
+        update_histogram(hist, h);
+        server->ProcessRequests();
+    }
+
+
+    delete server;
+    delete file;
+
+}

--- a/examples/shared_memory/server_sharedhistograms.cpp
+++ b/examples/shared_memory/server_sharedhistograms.cpp
@@ -1,0 +1,64 @@
+//
+// Created by Vetle Wegner Ingeberg on 28/04/2026.
+//
+
+#include <histogram/SharedHistograms.h>
+#include <sys/fcntl.h>
+#include <csignal>
+#include <thread>
+#include <chrono>
+#include <random>
+
+#include <sys/mman.h>   // shm_unlink
+#include <cerrno>
+
+char leaveprog = 'n';
+
+void keyb_int(int sig_num)
+{
+    if (sig_num == SIGINT || sig_num == SIGQUIT || sig_num == SIGTERM) {
+        printf("\n\nLeaving...\n");
+        leaveprog = 'y';
+    }
+}
+
+
+
+void CleanupPosixShm(const char* name)
+{
+    // Best-effort: remove any stale object with this name.
+    // Ignore failure if it doesn't exist.
+    if (shm_unlink(name) == -1 && errno != ENOENT) {
+        // Optional: log or handle unexpected errors.
+        perror("shm_unlink");
+    }
+}
+
+int main() {
+
+    signal(SIGINT, keyb_int); // set up interrupt handler (Ctrl-C)
+    signal(SIGQUIT, keyb_int);
+    signal(SIGTERM, keyb_int);
+    signal(SIGPIPE, SIG_IGN);
+
+    // First step is to clean up if the last run crashed.
+    CleanupPosixShm("/test");
+
+    auto creator = SharedHistograms::Create("test", 503316480, 30, true);
+
+    auto hist = creator.Create1D("hist", "hist", 65536, 0, 65536, "Channel [ch]");
+
+    std::random_device rd{};
+    std::mt19937 gen{rd()};
+    std::normal_distribution<double> dist{1332., 35.0};
+
+    while (leaveprog == 'n') {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        unsigned int x = gen() & 0xFFFF;
+        hist->Fill(x);
+
+        double y = dist(gen);
+        hist->Fill(y);
+    }
+
+}

--- a/include/histogram/SharedHistograms.h
+++ b/include/histogram/SharedHistograms.h
@@ -1,0 +1,134 @@
+#ifndef SHAREDHISTOGRAMS_H_
+#define SHAREDHISTOGRAMS_H_
+
+#include <histogram/Histograms.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+class SharedHistogram1D;
+class SharedHistogram2D;
+class SharedHistogram3D;
+
+using SharedHistogram1Dp = std::shared_ptr<SharedHistogram1D>;
+using SharedHistogram2Dp = std::shared_ptr<SharedHistogram2D>;
+using SharedHistogram3Dp = std::shared_ptr<SharedHistogram3D>;
+
+class SharedHistograms;
+
+class SharedHistogram1D : public Named {
+public:
+    using data_t = int64_t;
+
+    void Fill(Axis::bin_t x, data_t weight = 1);
+    data_t GetBinContent(Axis::index_t bin) const;
+    [[nodiscard]] const Axis &GetAxisX() const { return xaxis; }
+    [[nodiscard]] std::uint64_t GetEntries() const;
+    void Reset();
+
+private:
+    friend class SharedHistograms;
+    SharedHistogram1D(const std::string &name, const std::string &title, const std::string &path,
+                      Axis::index_t channels, Axis::bin_t left, Axis::bin_t right, const std::string &xtitle,
+                      std::uint64_t *entries_ptr, data_t *data_ptr, bool writable);
+
+    const Axis xaxis;
+    std::uint64_t *entries;
+    data_t *data;
+    bool writable;
+};
+
+class SharedHistogram2D : public Named {
+public:
+    using data_t = int64_t;
+
+    void Fill(Axis::bin_t x, Axis::bin_t y, data_t weight = 1);
+    data_t GetBinContent(Axis::index_t xbin, Axis::index_t ybin) const;
+    [[nodiscard]] const Axis &GetAxisX() const { return xaxis; }
+    [[nodiscard]] const Axis &GetAxisY() const { return yaxis; }
+    [[nodiscard]] std::uint64_t GetEntries() const;
+    void Reset();
+
+private:
+    friend class SharedHistograms;
+    SharedHistogram2D(const std::string &name, const std::string &title, const std::string &path,
+                      Axis::index_t xchannels, Axis::bin_t xleft, Axis::bin_t xright, const std::string &xtitle,
+                      Axis::index_t ychannels, Axis::bin_t yleft, Axis::bin_t yright, const std::string &ytitle,
+                      std::uint64_t *entries_ptr, data_t *data_ptr, bool writable);
+
+    [[nodiscard]] Axis::index_t FlatIndex(Axis::index_t xbin, Axis::index_t ybin) const;
+
+    const Axis xaxis;
+    const Axis yaxis;
+    std::uint64_t *entries;
+    data_t *data;
+    bool writable;
+};
+
+class SharedHistogram3D : public Named {
+public:
+    using data_t = int64_t;
+
+    void Fill(Axis::bin_t x, Axis::bin_t y, Axis::bin_t z, data_t weight = 1);
+    data_t GetBinContent(Axis::index_t xbin, Axis::index_t ybin, Axis::index_t zbin) const;
+    [[nodiscard]] const Axis &GetAxisX() const { return xaxis; }
+    [[nodiscard]] const Axis &GetAxisY() const { return yaxis; }
+    [[nodiscard]] const Axis &GetAxisZ() const { return zaxis; }
+    [[nodiscard]] std::uint64_t GetEntries() const;
+    void Reset();
+
+private:
+    friend class SharedHistograms;
+    SharedHistogram3D(const std::string &name, const std::string &title, const std::string &path,
+                      Axis::index_t xchannels, Axis::bin_t xleft, Axis::bin_t xright, const std::string &xtitle,
+                      Axis::index_t ychannels, Axis::bin_t yleft, Axis::bin_t yright, const std::string &ytitle,
+                      Axis::index_t zchannels, Axis::bin_t zleft, Axis::bin_t zright, const std::string &ztitle,
+                      std::uint64_t *entries_ptr, data_t *data_ptr, bool writable);
+
+    [[nodiscard]] Axis::index_t FlatIndex(Axis::index_t xbin, Axis::index_t ybin, Axis::index_t zbin) const;
+
+    const Axis xaxis;
+    const Axis yaxis;
+    const Axis zaxis;
+    std::uint64_t *entries;
+    data_t *data;
+    bool writable;
+};
+
+class SharedHistograms {
+public:
+    static SharedHistograms Create(const std::string &shared_name, std::size_t shared_memory_size,
+                                   std::size_t max_histograms = 256, bool unlink_on_destroy = false);
+    static SharedHistograms Attach(const std::string &shared_name, bool read_only = true);
+
+    SharedHistograms(SharedHistograms &&) noexcept;
+    SharedHistograms &operator=(SharedHistograms &&) noexcept;
+    SharedHistograms(const SharedHistograms &) = delete;
+    SharedHistograms &operator=(const SharedHistograms &) = delete;
+    ~SharedHistograms();
+
+    SharedHistogram1Dp Create1D(const std::string &name, const std::string &title, Axis::index_t channels,
+                                Axis::bin_t left, Axis::bin_t right, const std::string &xtitle,
+                                const std::string &path = "");
+    SharedHistogram2Dp Create2D(const std::string &name, const std::string &title, Axis::index_t xchannels,
+                                Axis::bin_t xleft, Axis::bin_t xright, const std::string &xtitle,
+                                Axis::index_t ychannels, Axis::bin_t yleft, Axis::bin_t yright,
+                                const std::string &ytitle, const std::string &path = "");
+    SharedHistogram3Dp Create3D(const std::string &name, const std::string &title, Axis::index_t xchannels,
+                                Axis::bin_t xleft, Axis::bin_t xright, const std::string &xtitle,
+                                Axis::index_t ychannels, Axis::bin_t yleft, Axis::bin_t yright,
+                                const std::string &ytitle, Axis::index_t zchannels, Axis::bin_t zleft,
+                                Axis::bin_t zright, const std::string &ztitle, const std::string &path = "");
+
+    SharedHistogram1Dp Find1D(const std::string &name) const;
+    SharedHistogram2Dp Find2D(const std::string &name) const;
+    SharedHistogram3Dp Find3D(const std::string &name) const;
+
+private:
+    struct Impl;
+    explicit SharedHistograms(std::unique_ptr<Impl> impl);
+    std::unique_ptr<Impl> impl;
+};
+
+#endif // SHAREDHISTOGRAMS_H_

--- a/include/histogram/internal/SharedMemoryBackend.h
+++ b/include/histogram/internal/SharedMemoryBackend.h
@@ -1,0 +1,30 @@
+#ifndef HISTOGRAM_INTERNAL_SHAREDMEMORYBACKEND_H
+#define HISTOGRAM_INTERNAL_SHAREDMEMORYBACKEND_H
+
+#include <cstddef>
+#include <string>
+
+namespace HistogramInternal {
+
+struct SharedMemoryHandle {
+    int fd;
+    void *address;
+    std::size_t size;
+    std::string name;
+    bool owner;
+    bool unlink_on_destroy;
+
+    SharedMemoryHandle();
+    SharedMemoryHandle(const SharedMemoryHandle &) = delete;
+    SharedMemoryHandle &operator=(const SharedMemoryHandle &) = delete;
+    SharedMemoryHandle(SharedMemoryHandle &&other) noexcept;
+    SharedMemoryHandle &operator=(SharedMemoryHandle &&other) noexcept;
+    ~SharedMemoryHandle();
+};
+
+SharedMemoryHandle CreateSharedMemory(const std::string &name, std::size_t size, bool unlink_on_destroy);
+SharedMemoryHandle AttachSharedMemory(const std::string &name, bool read_only);
+
+} // namespace HistogramInternal
+
+#endif // HISTOGRAM_INTERNAL_SHAREDMEMORYBACKEND_H

--- a/src/histogram/SharedHistograms.cpp
+++ b/src/histogram/SharedHistograms.cpp
@@ -1,0 +1,493 @@
+#include <histogram/SharedHistograms.h>
+#include <histogram/internal/SharedMemoryBackend.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+constexpr std::uint32_t kSharedMagic = 0x48535447; // HSTG
+constexpr std::uint32_t kSharedVersion = 1;
+constexpr std::size_t kStringFieldLength = 96;
+
+enum class SharedHistogramDimension : std::uint8_t { D1 = 1, D2 = 2, D3 = 3 };
+
+struct SharedHistogramHeader {
+    std::uint32_t magic;
+    std::uint32_t version;
+    std::uint64_t total_size;
+    std::uint64_t max_histograms;
+    std::uint64_t used_histograms;
+    std::uint64_t next_data_offset;
+};
+
+struct SharedHistogramDescriptor {
+    std::uint8_t in_use;
+    std::uint8_t dimension;
+    std::uint8_t reserved[6];
+
+    char name[kStringFieldLength];
+    char title[kStringFieldLength];
+    char path[kStringFieldLength];
+    char xtitle[kStringFieldLength];
+    char ytitle[kStringFieldLength];
+    char ztitle[kStringFieldLength];
+
+    std::uint64_t xchannels;
+    std::uint64_t ychannels;
+    std::uint64_t zchannels;
+
+    double xleft;
+    double xright;
+    double yleft;
+    double yright;
+    double zleft;
+    double zright;
+
+    std::uint64_t entries;
+    std::uint64_t data_offset;
+    std::uint64_t data_count;
+};
+
+static_assert(std::is_standard_layout<SharedHistogramHeader>::value, "Shared header must be standard layout");
+static_assert(std::is_standard_layout<SharedHistogramDescriptor>::value, "Shared descriptor must be standard layout");
+
+template <typename T>
+T *OffsetPtr(void *base, std::uint64_t offset)
+{
+    return reinterpret_cast<T *>(reinterpret_cast<std::uint8_t *>(base) + offset);
+}
+
+template <typename T>
+const T *OffsetPtr(const void *base, std::uint64_t offset)
+{
+    return reinterpret_cast<const T *>(reinterpret_cast<const std::uint8_t *>(base) + offset);
+}
+
+std::size_t RequiredDataCount1D(Axis::index_t xchannels)
+{
+    return xchannels + 2;
+}
+
+std::size_t RequiredDataCount2D(Axis::index_t xchannels, Axis::index_t ychannels)
+{
+    return (xchannels + 2) * (ychannels + 2);
+}
+
+std::size_t RequiredDataCount3D(Axis::index_t xchannels, Axis::index_t ychannels, Axis::index_t zchannels)
+{
+    return (xchannels + 2) * (ychannels + 2) * (zchannels + 2);
+}
+
+void CopyStringToField(std::array<char, kStringFieldLength> &dst, const std::string &src)
+{
+    dst.fill('\0');
+    if (src.empty()) {
+        return;
+    }
+    const std::size_t len = std::min(src.size(), kStringFieldLength - 1);
+    std::memcpy(dst.data(), src.data(), len);
+}
+
+void CopyStringToField(char dst[kStringFieldLength], const std::string &src)
+{
+    std::array<char, kStringFieldLength> buffer {};
+    CopyStringToField(buffer, src);
+    std::memcpy(dst, buffer.data(), kStringFieldLength);
+}
+
+std::string ReadField(const char src[kStringFieldLength])
+{
+    return std::string(src, ::strnlen(src, kStringFieldLength));
+}
+
+void EnsureWritable(bool writable)
+{
+    if (!writable) {
+        throw std::runtime_error("Shared histogram is read-only");
+    }
+}
+
+} // namespace
+
+struct SharedHistograms::Impl {
+    HistogramInternal::SharedMemoryHandle memory;
+    SharedHistogramHeader *header;
+    SharedHistogramDescriptor *descriptors;
+    bool creator;
+    bool writable;
+
+    explicit Impl(HistogramInternal::SharedMemoryHandle &&handle, bool creator_role, bool writable_mapping)
+        : memory(std::move(handle))
+        , header(reinterpret_cast<SharedHistogramHeader *>(memory.address))
+        , descriptors(OffsetPtr<SharedHistogramDescriptor>(memory.address, sizeof(SharedHistogramHeader)))
+        , creator(creator_role)
+        , writable(writable_mapping)
+    {
+    }
+
+    SharedHistogramDescriptor *FindDescriptor(const std::string &name) const
+    {
+        for (std::size_t i = 0; i < header->max_histograms; ++i) {
+            auto *d = &descriptors[i];
+            if (d->in_use == 0) {
+                continue;
+            }
+            if (ReadField(d->name) == name) {
+                return d;
+            }
+        }
+        return nullptr;
+    }
+
+    SharedHistogramDescriptor *CreateDescriptor(SharedHistogramDimension dim, const std::string &name,
+                                                const std::string &title, const std::string &path,
+                                                const std::string &xtitle, const std::string &ytitle,
+                                                const std::string &ztitle, Axis::index_t xchannels,
+                                                Axis::bin_t xleft, Axis::bin_t xright, Axis::index_t ychannels,
+                                                Axis::bin_t yleft, Axis::bin_t yright, Axis::index_t zchannels,
+                                                Axis::bin_t zleft, Axis::bin_t zright, std::size_t data_count)
+    {
+        if (!creator) {
+            throw std::runtime_error("Only creator can define shared histograms");
+        }
+        EnsureWritable(writable);
+
+        if (FindDescriptor(name) != nullptr) {
+            throw std::runtime_error("Histogram with name '" + name + "' already exists in shared memory");
+        }
+
+        SharedHistogramDescriptor *slot = nullptr;
+        for (std::size_t i = 0; i < header->max_histograms; ++i) {
+            if (descriptors[i].in_use == 0) {
+                slot = &descriptors[i];
+                break;
+            }
+        }
+        if (slot == nullptr) {
+            throw std::runtime_error("No free shared histogram descriptors");
+        }
+
+        const std::uint64_t bytes = static_cast<std::uint64_t>(data_count * sizeof(std::int64_t));
+        if (header->next_data_offset + bytes > header->total_size) {
+            throw std::runtime_error("Shared memory exhausted while creating histogram '" + name + "'");
+        }
+
+        std::memset(slot, 0, sizeof(SharedHistogramDescriptor));
+        slot->in_use = 1;
+        slot->dimension = static_cast<std::uint8_t>(dim);
+        CopyStringToField(slot->name, name);
+        CopyStringToField(slot->title, title);
+        CopyStringToField(slot->path, path);
+        CopyStringToField(slot->xtitle, xtitle);
+        CopyStringToField(slot->ytitle, ytitle);
+        CopyStringToField(slot->ztitle, ztitle);
+        slot->xchannels = xchannels;
+        slot->ychannels = ychannels;
+        slot->zchannels = zchannels;
+        slot->xleft = xleft;
+        slot->xright = xright;
+        slot->yleft = yleft;
+        slot->yright = yright;
+        slot->zleft = zleft;
+        slot->zright = zright;
+        slot->entries = 0;
+        slot->data_offset = header->next_data_offset;
+        slot->data_count = data_count;
+
+        auto *data = OffsetPtr<std::int64_t>(memory.address, slot->data_offset);
+        std::fill(data, data + data_count, 0);
+
+        header->next_data_offset += bytes;
+        header->used_histograms += 1;
+        return slot;
+    }
+
+    std::int64_t *GetData(const SharedHistogramDescriptor *d) const
+    {
+        return OffsetPtr<std::int64_t>(memory.address, d->data_offset);
+    }
+};
+
+SharedHistogram1D::SharedHistogram1D(const std::string &name, const std::string &title, const std::string &path,
+                                     Axis::index_t channels, Axis::bin_t left, Axis::bin_t right,
+                                     const std::string &xtitle, std::uint64_t *entries_ptr, data_t *data_ptr,
+                                     bool is_writable)
+    : Named(name, title, path)
+    , xaxis(name + "_xaxis", channels, left, right, xtitle)
+    , entries(entries_ptr)
+    , data(data_ptr)
+    , writable(is_writable)
+{
+}
+
+void SharedHistogram1D::Fill(Axis::bin_t x, data_t weight)
+{
+    EnsureWritable(writable);
+    *entries += 1;
+    data[xaxis.FindBin(x)] += weight;
+}
+
+SharedHistogram1D::data_t SharedHistogram1D::GetBinContent(Axis::index_t bin) const
+{
+    if (bin >= xaxis.GetBinCountAll()) {
+        return 0;
+    }
+    return data[bin];
+}
+
+std::uint64_t SharedHistogram1D::GetEntries() const { return *entries; }
+
+void SharedHistogram1D::Reset()
+{
+    EnsureWritable(writable);
+    for (Axis::index_t i = 0; i < xaxis.GetBinCountAll(); ++i) {
+        data[i] = 0;
+    }
+    *entries = 0;
+}
+
+SharedHistogram2D::SharedHistogram2D(const std::string &name, const std::string &title, const std::string &path,
+                                     Axis::index_t xchannels, Axis::bin_t xleft, Axis::bin_t xright,
+                                     const std::string &xtitle, Axis::index_t ychannels, Axis::bin_t yleft,
+                                     Axis::bin_t yright, const std::string &ytitle, std::uint64_t *entries_ptr,
+                                     data_t *data_ptr, bool is_writable)
+    : Named(name, title, path)
+    , xaxis(name + "_xaxis", xchannels, xleft, xright, xtitle)
+    , yaxis(name + "_yaxis", ychannels, yleft, yright, ytitle)
+    , entries(entries_ptr)
+    , data(data_ptr)
+    , writable(is_writable)
+{
+}
+
+Axis::index_t SharedHistogram2D::FlatIndex(Axis::index_t xbin, Axis::index_t ybin) const
+{
+    return xaxis.GetBinCountAll() * ybin + xbin;
+}
+
+void SharedHistogram2D::Fill(Axis::bin_t x, Axis::bin_t y, data_t weight)
+{
+    EnsureWritable(writable);
+    const auto xbin = xaxis.FindBin(x);
+    const auto ybin = yaxis.FindBin(y);
+    data[FlatIndex(xbin, ybin)] += weight;
+    *entries += 1;
+}
+
+SharedHistogram2D::data_t SharedHistogram2D::GetBinContent(Axis::index_t xbin, Axis::index_t ybin) const
+{
+    if (xbin >= xaxis.GetBinCountAll() || ybin >= yaxis.GetBinCountAll()) {
+        return 0;
+    }
+    return data[FlatIndex(xbin, ybin)];
+}
+
+std::uint64_t SharedHistogram2D::GetEntries() const { return *entries; }
+
+void SharedHistogram2D::Reset()
+{
+    EnsureWritable(writable);
+    const auto yall = yaxis.GetBinCountAll();
+    const auto xall = xaxis.GetBinCountAll();
+    for (Axis::index_t y = 0; y < yall; ++y) {
+        for (Axis::index_t x = 0; x < xall; ++x) {
+            data[FlatIndex(x, y)] = 0;
+        }
+    }
+    *entries = 0;
+}
+
+SharedHistogram3D::SharedHistogram3D(const std::string &name, const std::string &title, const std::string &path,
+                                     Axis::index_t xchannels, Axis::bin_t xleft, Axis::bin_t xright,
+                                     const std::string &xtitle, Axis::index_t ychannels, Axis::bin_t yleft,
+                                     Axis::bin_t yright, const std::string &ytitle, Axis::index_t zchannels,
+                                     Axis::bin_t zleft, Axis::bin_t zright, const std::string &ztitle,
+                                     std::uint64_t *entries_ptr, data_t *data_ptr, bool is_writable)
+    : Named(name, title, path)
+    , xaxis(name + "_xaxis", xchannels, xleft, xright, xtitle)
+    , yaxis(name + "_yaxis", ychannels, yleft, yright, ytitle)
+    , zaxis(name + "_zaxis", zchannels, zleft, zright, ztitle)
+    , entries(entries_ptr)
+    , data(data_ptr)
+    , writable(is_writable)
+{
+}
+
+Axis::index_t SharedHistogram3D::FlatIndex(Axis::index_t xbin, Axis::index_t ybin, Axis::index_t zbin) const
+{
+    return xaxis.GetBinCountAll() * yaxis.GetBinCountAll() * zbin + xaxis.GetBinCountAll() * ybin + xbin;
+}
+
+void SharedHistogram3D::Fill(Axis::bin_t x, Axis::bin_t y, Axis::bin_t z, data_t weight)
+{
+    EnsureWritable(writable);
+    const auto xbin = xaxis.FindBin(x);
+    const auto ybin = yaxis.FindBin(y);
+    const auto zbin = zaxis.FindBin(z);
+    data[FlatIndex(xbin, ybin, zbin)] += weight;
+    *entries += 1;
+}
+
+SharedHistogram3D::data_t SharedHistogram3D::GetBinContent(Axis::index_t xbin, Axis::index_t ybin,
+                                                           Axis::index_t zbin) const
+{
+    if (xbin >= xaxis.GetBinCountAll() || ybin >= yaxis.GetBinCountAll() || zbin >= zaxis.GetBinCountAll()) {
+        return 0;
+    }
+    return data[FlatIndex(xbin, ybin, zbin)];
+}
+
+std::uint64_t SharedHistogram3D::GetEntries() const { return *entries; }
+
+void SharedHistogram3D::Reset()
+{
+    EnsureWritable(writable);
+    const auto xall = xaxis.GetBinCountAll();
+    const auto yall = yaxis.GetBinCountAll();
+    const auto zall = zaxis.GetBinCountAll();
+    for (Axis::index_t z = 0; z < zall; ++z) {
+        for (Axis::index_t y = 0; y < yall; ++y) {
+            for (Axis::index_t x = 0; x < xall; ++x) {
+                data[FlatIndex(x, y, z)] = 0;
+            }
+        }
+    }
+    *entries = 0;
+}
+
+SharedHistograms::SharedHistograms(std::unique_ptr<Impl> pimpl)
+    : impl(std::move(pimpl))
+{
+}
+
+SharedHistograms::~SharedHistograms() = default;
+SharedHistograms::SharedHistograms(SharedHistograms &&) noexcept = default;
+SharedHistograms &SharedHistograms::operator=(SharedHistograms &&) noexcept = default;
+
+SharedHistograms SharedHistograms::Create(const std::string &shared_name, std::size_t shared_memory_size,
+                                          std::size_t max_histograms, bool unlink_on_destroy)
+{
+    if (max_histograms == 0) {
+        throw std::runtime_error("max_histograms must be larger than 0");
+    }
+    const std::size_t minimum_size =
+            sizeof(SharedHistogramHeader) + max_histograms * sizeof(SharedHistogramDescriptor) + sizeof(std::int64_t);
+    if (shared_memory_size < minimum_size) {
+        throw std::runtime_error("shared_memory_size is too small for header and descriptor table");
+    }
+
+    auto mem = HistogramInternal::CreateSharedMemory(shared_name, shared_memory_size, unlink_on_destroy);
+    auto *header = reinterpret_cast<SharedHistogramHeader *>(mem.address);
+    std::memset(mem.address, 0, shared_memory_size);
+    header->magic = kSharedMagic;
+    header->version = kSharedVersion;
+    header->total_size = shared_memory_size;
+    header->max_histograms = max_histograms;
+    header->used_histograms = 0;
+    header->next_data_offset = sizeof(SharedHistogramHeader) + max_histograms * sizeof(SharedHistogramDescriptor);
+
+    return SharedHistograms(std::make_unique<Impl>(std::move(mem), true, true));
+}
+
+SharedHistograms SharedHistograms::Attach(const std::string &shared_name, bool read_only)
+{
+    auto mem = HistogramInternal::AttachSharedMemory(shared_name, read_only);
+    auto *header = reinterpret_cast<SharedHistogramHeader *>(mem.address);
+    if (header->magic != kSharedMagic) {
+        throw std::runtime_error("Shared memory segment has invalid histogram magic");
+    }
+    if (header->version != kSharedVersion) {
+        throw std::runtime_error("Shared memory segment has incompatible version");
+    }
+    return SharedHistograms(std::make_unique<Impl>(std::move(mem), false, !read_only));
+}
+
+SharedHistogram1Dp SharedHistograms::Create1D(const std::string &name, const std::string &title,
+                                              Axis::index_t channels, Axis::bin_t left, Axis::bin_t right,
+                                              const std::string &xtitle, const std::string &path)
+{
+    auto *d = impl->CreateDescriptor(SharedHistogramDimension::D1, name, title, path, xtitle, "", "", channels, left,
+                                     right, 0, 0, 0, 0, 0, 0, RequiredDataCount1D(channels));
+    auto *data = impl->GetData(d);
+    return SharedHistogram1Dp(new SharedHistogram1D(ReadField(d->name), ReadField(d->title), ReadField(d->path),
+                                                    d->xchannels, d->xleft, d->xright, ReadField(d->xtitle),
+                                                    &d->entries, data, impl->writable));
+}
+
+SharedHistogram2Dp SharedHistograms::Create2D(const std::string &name, const std::string &title, Axis::index_t xchannels,
+                                              Axis::bin_t xleft, Axis::bin_t xright, const std::string &xtitle,
+                                              Axis::index_t ychannels, Axis::bin_t yleft, Axis::bin_t yright,
+                                              const std::string &ytitle, const std::string &path)
+{
+    auto *d = impl->CreateDescriptor(SharedHistogramDimension::D2, name, title, path, xtitle, ytitle, "", xchannels,
+                                     xleft, xright, ychannels, yleft, yright, 0, 0, 0,
+                                     RequiredDataCount2D(xchannels, ychannels));
+    auto *data = impl->GetData(d);
+    return SharedHistogram2Dp(new SharedHistogram2D(ReadField(d->name), ReadField(d->title), ReadField(d->path),
+                                                    d->xchannels, d->xleft, d->xright, ReadField(d->xtitle),
+                                                    d->ychannels, d->yleft, d->yright, ReadField(d->ytitle),
+                                                    &d->entries, data, impl->writable));
+}
+
+SharedHistogram3Dp SharedHistograms::Create3D(const std::string &name, const std::string &title, Axis::index_t xchannels,
+                                              Axis::bin_t xleft, Axis::bin_t xright, const std::string &xtitle,
+                                              Axis::index_t ychannels, Axis::bin_t yleft, Axis::bin_t yright,
+                                              const std::string &ytitle, Axis::index_t zchannels, Axis::bin_t zleft,
+                                              Axis::bin_t zright, const std::string &ztitle, const std::string &path)
+{
+    auto *d = impl->CreateDescriptor(SharedHistogramDimension::D3, name, title, path, xtitle, ytitle, ztitle,
+                                     xchannels, xleft, xright, ychannels, yleft, yright, zchannels, zleft, zright,
+                                     RequiredDataCount3D(xchannels, ychannels, zchannels));
+    auto *data = impl->GetData(d);
+    return SharedHistogram3Dp(new SharedHistogram3D(
+            ReadField(d->name), ReadField(d->title), ReadField(d->path), d->xchannels, d->xleft, d->xright,
+            ReadField(d->xtitle), d->ychannels, d->yleft, d->yright, ReadField(d->ytitle), d->zchannels, d->zleft,
+            d->zright, ReadField(d->ztitle), &d->entries, data, impl->writable));
+}
+
+SharedHistogram1Dp SharedHistograms::Find1D(const std::string &name) const
+{
+    auto *d = impl->FindDescriptor(name);
+    if (d == nullptr || d->dimension != static_cast<std::uint8_t>(SharedHistogramDimension::D1)) {
+        return nullptr;
+    }
+    auto *data = impl->GetData(d);
+    return SharedHistogram1Dp(new SharedHistogram1D(ReadField(d->name), ReadField(d->title), ReadField(d->path),
+                                                    d->xchannels, d->xleft, d->xright, ReadField(d->xtitle),
+                                                    &d->entries, data, impl->writable));
+}
+
+SharedHistogram2Dp SharedHistograms::Find2D(const std::string &name) const
+{
+    auto *d = impl->FindDescriptor(name);
+    if (d == nullptr || d->dimension != static_cast<std::uint8_t>(SharedHistogramDimension::D2)) {
+        return nullptr;
+    }
+    auto *data = impl->GetData(d);
+    return SharedHistogram2Dp(new SharedHistogram2D(ReadField(d->name), ReadField(d->title), ReadField(d->path),
+                                                    d->xchannels, d->xleft, d->xright, ReadField(d->xtitle),
+                                                    d->ychannels, d->yleft, d->yright, ReadField(d->ytitle),
+                                                    &d->entries, data, impl->writable));
+}
+
+SharedHistogram3Dp SharedHistograms::Find3D(const std::string &name) const
+{
+    auto *d = impl->FindDescriptor(name);
+    if (d == nullptr || d->dimension != static_cast<std::uint8_t>(SharedHistogramDimension::D3)) {
+        return nullptr;
+    }
+    auto *data = impl->GetData(d);
+    return SharedHistogram3Dp(new SharedHistogram3D(
+            ReadField(d->name), ReadField(d->title), ReadField(d->path), d->xchannels, d->xleft, d->xright,
+            ReadField(d->xtitle), d->ychannels, d->yleft, d->yright, ReadField(d->ytitle), d->zchannels, d->zleft,
+            d->zright, ReadField(d->ztitle), &d->entries, data, impl->writable));
+}

--- a/src/histogram/internal/SharedMemoryBackendPosix.cpp
+++ b/src/histogram/internal/SharedMemoryBackendPosix.cpp
@@ -1,0 +1,182 @@
+#include <histogram/internal/SharedMemoryBackend.h>
+
+#include <stdexcept>
+
+#if defined(__linux__) || defined(__APPLE__)
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include <utility>
+
+namespace HistogramInternal {
+
+namespace {
+
+std::string EnsureSharedMemoryName(const std::string &name)
+{
+    if (name.empty()) {
+        throw std::runtime_error("Shared memory name cannot be empty");
+    }
+    if (name[0] == '/') {
+        return name;
+    }
+    return "/" + name;
+}
+
+[[noreturn]] void ThrowErrno(const std::string &prefix)
+{
+    throw std::runtime_error(prefix + ": " + std::strerror(errno));
+}
+
+} // namespace
+
+SharedMemoryHandle::SharedMemoryHandle()
+    : fd(-1), address(nullptr), size(0), owner(false), unlink_on_destroy(false)
+{
+}
+
+SharedMemoryHandle::SharedMemoryHandle(SharedMemoryHandle &&other) noexcept
+    : fd(other.fd)
+    , address(other.address)
+    , size(other.size)
+    , name(std::move(other.name))
+    , owner(other.owner)
+    , unlink_on_destroy(other.unlink_on_destroy)
+{
+    other.fd = -1;
+    other.address = nullptr;
+    other.size = 0;
+    other.owner = false;
+    other.unlink_on_destroy = false;
+}
+
+SharedMemoryHandle &SharedMemoryHandle::operator=(SharedMemoryHandle &&other) noexcept
+{
+    if (this == &other) {
+        return *this;
+    }
+    this->~SharedMemoryHandle();
+    fd = other.fd;
+    address = other.address;
+    size = other.size;
+    name = std::move(other.name);
+    owner = other.owner;
+    unlink_on_destroy = other.unlink_on_destroy;
+
+    other.fd = -1;
+    other.address = nullptr;
+    other.size = 0;
+    other.owner = false;
+    other.unlink_on_destroy = false;
+    return *this;
+}
+
+SharedMemoryHandle::~SharedMemoryHandle()
+{
+    if (address != nullptr && size > 0) {
+        munmap(address, size);
+    }
+    if (fd >= 0) {
+        close(fd);
+    }
+    if (owner && unlink_on_destroy && !name.empty()) {
+        shm_unlink(name.c_str());
+    }
+}
+
+SharedMemoryHandle CreateSharedMemory(const std::string &name, std::size_t size, bool unlink_on_destroy)
+{
+    if (size == 0) {
+        throw std::runtime_error("Shared memory size must be larger than 0");
+    }
+
+    SharedMemoryHandle handle;
+    handle.name = EnsureSharedMemoryName(name);
+    handle.owner = true;
+    handle.unlink_on_destroy = unlink_on_destroy;
+    handle.size = size;
+
+    handle.fd = shm_open(handle.name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (handle.fd < 0) {
+        ThrowErrno("Failed to create shared memory");
+    }
+
+    if (ftruncate(handle.fd, static_cast<off_t>(size)) != 0) {
+        ThrowErrno("Failed to resize shared memory");
+    }
+
+    handle.address = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, handle.fd, 0);
+    if (handle.address == MAP_FAILED) {
+        handle.address = nullptr;
+        ThrowErrno("Failed to map shared memory");
+    }
+
+    return handle;
+}
+
+SharedMemoryHandle AttachSharedMemory(const std::string &name, bool read_only)
+{
+    SharedMemoryHandle handle;
+    handle.name = EnsureSharedMemoryName(name);
+    handle.owner = false;
+    handle.unlink_on_destroy = false;
+
+    const int open_flags = read_only ? O_RDONLY : O_RDWR;
+    handle.fd = shm_open(handle.name.c_str(), open_flags, 0600);
+    if (handle.fd < 0) {
+        ThrowErrno("Failed to open shared memory");
+    }
+
+    struct stat sb {};
+    if (fstat(handle.fd, &sb) != 0) {
+        ThrowErrno("Failed to inspect shared memory");
+    }
+    if (sb.st_size <= 0) {
+        throw std::runtime_error("Shared memory has invalid size");
+    }
+    handle.size = static_cast<std::size_t>(sb.st_size);
+
+    const int prot = read_only ? PROT_READ : (PROT_READ | PROT_WRITE);
+    handle.address = mmap(nullptr, handle.size, prot, MAP_SHARED, handle.fd, 0);
+    if (handle.address == MAP_FAILED) {
+        handle.address = nullptr;
+        ThrowErrno("Failed to map shared memory");
+    }
+
+    return handle;
+}
+
+} // namespace HistogramInternal
+
+#else
+
+namespace HistogramInternal {
+
+SharedMemoryHandle::SharedMemoryHandle()
+    : fd(-1), address(nullptr), size(0), owner(false), unlink_on_destroy(false)
+{
+}
+
+SharedMemoryHandle::SharedMemoryHandle(SharedMemoryHandle &&other) noexcept = default;
+SharedMemoryHandle &SharedMemoryHandle::operator=(SharedMemoryHandle &&other) noexcept = default;
+SharedMemoryHandle::~SharedMemoryHandle() = default;
+
+SharedMemoryHandle CreateSharedMemory(const std::string &, std::size_t, bool)
+{
+    throw std::runtime_error("Shared memory is only supported on Linux and macOS");
+}
+
+SharedMemoryHandle AttachSharedMemory(const std::string &, bool)
+{
+    throw std::runtime_error("Shared memory is only supported on Linux and macOS");
+}
+
+} // namespace HistogramInternal
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ include(../cmake/tools.cmake)
 
 include(../cmake/CPM.cmake)
 
-CPMAddPackage("gh:doctest/doctest@2.4.12")
+CPMAddPackage("gh:doctest/doctest@2.5.2")
 CPMAddPackage("gh:TheLartians/Format.cmake@1.8.3")
 
 if(TEST_INSTALLED_VERSION)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(${PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Histogram.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ThreadSafeHistogram.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/SharedHistograms.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} doctest::doctest OCL::Histogram)

--- a/test/src/SharedHistograms.cpp
+++ b/test/src/SharedHistograms.cpp
@@ -1,0 +1,85 @@
+#include <doctest/doctest.h>
+
+#include <histogram/SharedHistograms.h>
+
+#include <string>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+TEST_SUITE_BEGIN("SharedHistograms");
+
+namespace {
+
+std::string MakeSharedName(const std::string &suffix)
+{
+#if defined(__linux__) || defined(__APPLE__)
+    return "/histogram_test_" + suffix + "_" + std::to_string(static_cast<long long>(::getpid()));
+#else
+    return "histogram_test_" + suffix;
+#endif
+}
+
+} // namespace
+
+TEST_CASE("Creator and consumer can share 1D/2D/3D histograms")
+{
+#if defined(__linux__) || defined(__APPLE__)
+    const std::string shared_name = MakeSharedName("basic");
+    ::shm_unlink(shared_name.c_str());
+
+    auto creator = SharedHistograms::Create(shared_name, 4 * 1024 * 1024, 16, true);
+    auto h1 = creator.Create1D("h1", "title1", 16, 0, 16, "x");
+    auto h2 = creator.Create2D("h2", "title2", 8, 0, 8, "x", 10, -5, 5, "y");
+    auto h3 = creator.Create3D("h3", "title3", 4, 0, 4, "x", 5, 0, 5, "y", 6, 0, 6, "z");
+
+    h1->Fill(4.2, 3);
+    h2->Fill(1.1, 2.2, 5);
+    h3->Fill(1.1, 2.2, 3.3, 7);
+
+    auto consumer = SharedHistograms::Attach(shared_name);
+    auto c1 = consumer.Find1D("h1");
+    auto c2 = consumer.Find2D("h2");
+    auto c3 = consumer.Find3D("h3");
+
+    REQUIRE(c1 != nullptr);
+    REQUIRE(c2 != nullptr);
+    REQUIRE(c3 != nullptr);
+
+    CHECK(c1->GetEntries() == 1);
+    CHECK(c2->GetEntries() == 1);
+    CHECK(c3->GetEntries() == 1);
+
+    CHECK(c1->GetBinContent(c1->GetAxisX().FindBin(4.2)) == 3);
+    CHECK(c2->GetBinContent(c2->GetAxisX().FindBin(1.1), c2->GetAxisY().FindBin(2.2)) == 5);
+    CHECK(c3->GetBinContent(c3->GetAxisX().FindBin(1.1), c3->GetAxisY().FindBin(2.2), c3->GetAxisZ().FindBin(3.3)) ==
+          7);
+#else
+    CHECK_THROWS(SharedHistograms::Create("unsupported", 1024, 2, true));
+#endif
+}
+
+TEST_CASE("Consumer cannot create histograms")
+{
+#if defined(__linux__) || defined(__APPLE__)
+    const std::string shared_name = MakeSharedName("readonly");
+    ::shm_unlink(shared_name.c_str());
+
+    auto creator = SharedHistograms::Create(shared_name, 2 * 1024 * 1024, 8, true);
+    creator.Create1D("h1", "title1", 16, 0, 16, "x");
+
+    auto consumer = SharedHistograms::Attach(shared_name);
+    CHECK_THROWS(consumer.Create1D("h2", "title2", 16, 0, 16, "x"));
+#else
+    CHECK(true);
+#endif
+}
+
+TEST_CASE("Shared attach fails on missing segment")
+{
+    CHECK_THROWS(SharedHistograms::Attach("/histogram_non_existing_segment_123456"));
+}
+
+TEST_SUITE_END();

--- a/test/src/SharedHistograms.cpp
+++ b/test/src/SharedHistograms.cpp
@@ -43,10 +43,12 @@ TEST_CASE("Creator and consumer can share 1D/2D/3D histograms")
     auto c1 = consumer.Find1D("h1");
     auto c2 = consumer.Find2D("h2");
     auto c3 = consumer.Find3D("h3");
+    auto c4 = consumer.Find3D("h4");
 
-    REQUIRE(c1 != nullptr);
-    REQUIRE(c2 != nullptr);
-    REQUIRE(c3 != nullptr);
+    REQUIRE(c1.get() != nullptr);
+    REQUIRE(c2.get() != nullptr);
+    REQUIRE(c3.get() != nullptr);
+    REQUIRE(c4.get() == nullptr);
 
     CHECK(c1->GetEntries() == 1);
     CHECK(c2->GetEntries() == 1);
@@ -54,8 +56,7 @@ TEST_CASE("Creator and consumer can share 1D/2D/3D histograms")
 
     CHECK(c1->GetBinContent(c1->GetAxisX().FindBin(4.2)) == 3);
     CHECK(c2->GetBinContent(c2->GetAxisX().FindBin(1.1), c2->GetAxisY().FindBin(2.2)) == 5);
-    CHECK(c3->GetBinContent(c3->GetAxisX().FindBin(1.1), c3->GetAxisY().FindBin(2.2), c3->GetAxisZ().FindBin(3.3)) ==
-          7);
+    CHECK(c3->GetBinContent(c3->GetAxisX().FindBin(1.1), c3->GetAxisY().FindBin(2.2), c3->GetAxisZ().FindBin(3.3)) == 7);
 #else
     CHECK_THROWS(SharedHistograms::Create("unsupported", 1024, 2, true));
 #endif


### PR DESCRIPTION
I've added functionality for the histograms to reside in shared memory.
This will allow for easy monitoring of the histograms during online sort (or offline while its sorting).